### PR TITLE
Fixed the utcnow() soon deprecated warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,28 @@
+# Please enter files and folders to be ignored by git. Lines starting
+#
+# with '#' or blank lines will be ignored.
+# Standard glob patterns work, and will be applied recursively throughout the entire working tree.
+# You can start patterns with a forward slash (/) to avoid recursivity.
+# You can end patterns with a forward slash (/) to specify a directory.
+# You can negate a pattern by starting it with an exclamation point (!).
+#
+# it is also possible to have additional .gitignore files in subdirectories. 
+# The rules in these nested 
+#
+# /TODO        ignore folder TODO
+# TODO/        ignore file TODO
+# doc/*.txt    ignore doc/notes.txt, but not doc/server/arch.txt
+# doc/**/*.pdf ignore all .pdf files in folder doc subfolders
+#
+# documentation at: https://git-scm.com/docs/gitignore
+# Samples at: https://github.com/github/gitignore
+
+# Virtual environments
+.venv/
+venv/
+
+# Python cache
+__pycache__
+
+# Scirtscan resultfiles
+/[0-9]*

--- a/scirtscan.py
+++ b/scirtscan.py
@@ -842,11 +842,12 @@ def check_ssl_certificate_validity(website):
 
         # Get the expiration date of the certificate
         cert_expiration = datetime.datetime.strptime(cert_info['notAfter'], '%b %d %H:%M:%S %Y %Z')
+        cert_expiration = cert_expiration.astimezone(datetime.timezone.utc)     # All certificates use UTC time    
 
         # Get the issuer information of the certificate [not used right now 20230701]
         cert_ca = cert_info['issuer']
 
-        current_time = datetime.datetime.utcnow()
+        current_time = datetime.datetime.now(datetime.timezone.utc)
         days_left = (cert_expiration - current_time).days
         if days_left > 29:
             outfile.write("OK\n")


### PR DESCRIPTION
Beamzer,
Scirtscan gaf een warning dat de functie utcnow() binnenkort deprecated zal zijn. Het is zo te lezen een python 2 functie die nog lang is ondersteung in 3. Ik heb de code omgeschreven naar python 3. 